### PR TITLE
fix: theme edit/delete routes to use UUID instead of name

### DIFF
--- a/src/routers/themes.py
+++ b/src/routers/themes.py
@@ -1,4 +1,5 @@
 from typing import Annotated, Any
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -146,21 +147,21 @@ async def create_theme(
 
 
 @router.get(
-    "/{name}",
+    "/{id}",
     status_code=status.HTTP_200_OK,
     response_class=HTMLResponse,
-    summary="Gets theme by name for update",
+    summary="Gets theme by id for update",
     responses={
         404: {"description": "Theme not found"},
     },
 )
 async def get_theme(
-    name: str,
+    id: UUID,
     request: Request,
     context: dict[str, Any] = Depends(get_template_context),
     service: ThemeService = Depends(get_theme_service),
 ):
-    theme = await service.get_theme_by_name(name)
+    theme = await service.get_theme_by_id(id)
     if not theme:
         context.update(
             {
@@ -178,12 +179,14 @@ async def get_theme(
     existing_colors = await service.get_existing_colors()
     colors = list(THEME_COLORS - existing_colors)
     colors.insert(0, theme.color)
-    context.update({"theme_name": name, "colors": colors})
+    context.update(
+        {"theme_id": str(theme.id), "theme_name": theme.name, "colors": colors}
+    )
     return templates.TemplateResponse(request, "themes/themes_update.html", context)
 
 
 @router.put(
-    "/{name}",
+    "/{id}",
     status_code=status.HTTP_200_OK,
     response_class=JSONResponse,
     summary="Updates theme",
@@ -194,15 +197,15 @@ async def get_theme(
     },
 )
 async def update_theme(
-    name: str,
+    id: UUID,
     theme_data: ThemeUpdate,
     service: ThemeService = Depends(get_user_theme_service),
 ):
-    theme = await service.get_theme_by_name(name)
+    theme = await service.get_theme_by_id(id)
     if not theme:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Theme with name {name} not found",
+            detail=f"Theme with id {id} not found",
         )
     try:
         res = await service.update_theme(theme, theme_data)
@@ -223,17 +226,17 @@ async def update_theme(
 
 
 @router.delete(
-    "/{name}",
+    "/{id}",
     status_code=status.HTTP_204_NO_CONTENT,
     description="Deletes theme",
     dependencies=_WRITE_ROUTE_DEPENDENCIES,
 )
 async def delete_theme(
-    name: str,
+    id: UUID,
     service: ThemeService = Depends(get_user_theme_service),
 ):
     try:
-        res = await service.delete_theme(name)
+        res = await service.delete_theme(id)
     except RuntimeError:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/services/themes.py
+++ b/src/services/themes.py
@@ -1,5 +1,6 @@
 import hashlib
 import random
+from uuid import UUID
 
 from src.repositories import ThemeRepository
 from src.schemas import (
@@ -50,6 +51,9 @@ class ThemeService:
     async def get_theme_by_name(self, theme_name: str) -> ThemeInDB | None:
         return await self.theme_repo.get_by_name(theme_name)
 
+    async def get_theme_by_id(self, theme_id: UUID) -> ThemeInDB | None:
+        return await self.theme_repo.get_by_id(theme_id)
+
     async def update_theme(
         self, old_theme: ThemeInDB, theme_data: ThemeUpdate
     ) -> ThemeInDB | None:
@@ -89,11 +93,8 @@ class ThemeService:
         updated_theme = ThemeUpdate(**update_dict)
         return await self.theme_repo.update(old_theme.id, updated_theme)
 
-    async def delete_theme(self, theme: str) -> bool:
-        theme_obj = await self.theme_repo.get_by_name(theme)
-        if theme_obj:
-            return await self.theme_repo.delete(theme_obj.id)
-        return False
+    async def delete_theme(self, theme_id: UUID) -> bool:
+        return await self.theme_repo.delete(theme_id)
 
     async def list_themes(
         self, skip: int = 0, limit: int | None = 100

--- a/src/static/js/list_themes.js
+++ b/src/static/js/list_themes.js
@@ -1,17 +1,17 @@
 // Функция для редактирования темы (перенаправление на страницу редактирования)
-function editTheme(themeName) {
+function editTheme(themeId) {
     // Перенаправляем на страницу редактирования темы
-    window.location.href = `/themes/${encodeURIComponent(themeName)}`;
+    window.location.href = `/themes/${encodeURIComponent(themeId)}`;
 }
 
 // Функция для удаления темы
-async function deleteTheme(themeName) {
+async function deleteTheme(themeId) {
     if (!confirm('Вы уверены, что хотите удалить эту тему? Все задачи с этой темой будут перемещены в "Без темы".')) {
         return;
     }
 
     try {
-        const response = await fetch(`/themes/${encodeURIComponent(themeName)}`, {
+        const response = await fetch(`/themes/${encodeURIComponent(themeId)}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',
@@ -23,13 +23,16 @@ async function deleteTheme(themeName) {
             showNotification('Тема удалена', 'success');
 
             // Удаляем элемент из DOM
-            const themeElement = findThemeCardByName(themeName);
+            const themeElement = findThemeCardById(themeId);
             if (themeElement) {
+                const themeName = themeElement.dataset.themeName;
                 themeElement.remove();
-            }
 
-            // Обновляем список тем в сайдбаре если есть
-            updateSidebarThemes(themeName);
+                // Обновляем список тем в сайдбаре если есть (там фильтр по имени)
+                if (themeName) {
+                    updateSidebarThemes(themeName);
+                }
+            }
 
             // Перезагружаем страницу через 1 секунду
             setTimeout(() => {
@@ -59,7 +62,7 @@ function updateSidebarThemes(deletedThemeName) {
     });
 }
 
-function findThemeCardByName(themeName) {
-    const cards = document.querySelectorAll('.theme-card[data-theme-name]');
-    return Array.from(cards).find(card => card.dataset.themeName === themeName) || null;
+function findThemeCardById(themeId) {
+    const cards = document.querySelectorAll('.theme-card[data-theme-id]');
+    return Array.from(cards).find(card => card.dataset.themeId === themeId) || null;
 }

--- a/src/templates/themes/themes_list.html
+++ b/src/templates/themes/themes_list.html
@@ -23,10 +23,10 @@
                 <span class="stat">{{ theme.habits_count }} {{ plural.pluralize(theme.habits_count, 'привычка', 'привычки', 'привычек') }}</span>
             </div>
             <div class="theme-actions">
-                <button class="btn btn-outline btn-sm" onclick='editTheme({{ theme.name|tojson }})'>
+                <button class="btn btn-outline btn-sm" onclick='editTheme({{ theme.id|string|tojson }})'>
                     <i class="fas fa-edit"></i> Изменить
                 </button>
-                <button class="btn btn-danger btn-sm" onclick='deleteTheme({{ theme.name|tojson }})'>
+                <button class="btn btn-danger btn-sm" onclick='deleteTheme({{ theme.id|string|tojson }})'>
                     <i class="fas fa-trash"></i> Удалить
                 </button>
             </div>

--- a/src/templates/themes/themes_update.html
+++ b/src/templates/themes/themes_update.html
@@ -59,7 +59,7 @@
 <script src="{{ url_for('static', path='/js/update.js') }}"></script>
 {% endblock %}
 
-{% block form_action %}/themes/{{theme_name}}{% endblock %}
+{% block form_action %}/themes/{{ theme_id }}{% endblock %}
 
 {% block cancel_url %}/themes{% endblock %}
 

--- a/tests/api_unit/test_themes_router_unit.py
+++ b/tests/api_unit/test_themes_router_unit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi import Request
@@ -50,6 +50,8 @@ class _FakeThemeService:
         update_error: Exception | None = None,
         update_returns_none: bool = False,
         themes_count: int = 0,
+        theme_id: UUID | None = None,
+        theme_name: str = "Hobby",
     ):
         self.exists = exists
         self.create_error = create_error
@@ -57,6 +59,8 @@ class _FakeThemeService:
         self.update_error = update_error
         self.update_returns_none = update_returns_none
         self.themes_count = themes_count
+        self.theme_id = theme_id or uuid4()
+        self.theme_name = theme_name
 
     async def list_themes_with_counts(
         self, page: int = 1, per_page: int = 20
@@ -73,10 +77,19 @@ class _FakeThemeService:
             return None
         return _mk_theme(theme_data.name, theme_data.color or "#FF00FF")
 
-    async def get_theme_by_name(self, name: str) -> ThemeInDB | None:
+    async def get_theme_by_id(self, id: UUID) -> ThemeInDB | None:
         if not self.exists:
             return None
-        return _mk_theme(name, "#FF00FF")
+        if id != self.theme_id:
+            return None
+        now = datetime(2026, 1, 1, 0, 0, 0)
+        return ThemeInDB(
+            id=self.theme_id,
+            name=self.theme_name,
+            color="#FF00FF",
+            created_at=now,
+            updated_at=now,
+        )
 
     async def update_theme(
         self,
@@ -90,8 +103,10 @@ class _FakeThemeService:
         dump = theme_data.model_dump(exclude_unset=True)
         return old_theme.model_copy(update=dump)
 
-    async def delete_theme(self, theme: str) -> None:
-        return None
+    async def delete_theme(self, id: UUID) -> bool:
+        if not self.exists:
+            return False
+        return id == self.theme_id
 
 
 def _override_theme_service(service: _FakeThemeService) -> None:
@@ -126,13 +141,16 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
 async def test_update_theme_returns_404_when_missing(client: AsyncClient) -> None:
     _override_theme_service(_FakeThemeService(exists=False))
 
-    res = await client.put("/themes/Nope", json={"name": "X"})
+    res = await client.put(f"/themes/{uuid4()}", json={"name": "X"})
 
     assert_json_response(res, status_code=404)
 
 
 async def test_update_theme_returns_success_payload(client: AsyncClient) -> None:
-    res = await client.put("/themes/Hobby", json={"color": "#FFFFFF"})
+    theme_id = uuid4()
+    _override_theme_service(_FakeThemeService(theme_id=theme_id, theme_name="Hobby"))
+
+    res = await client.put(f"/themes/{theme_id}", json={"color": "#FFFFFF"})
 
     assert_json_response(res, status_code=200)
     data = res.json()
@@ -158,9 +176,10 @@ async def test_update_theme_returns_expected_json_error(
     expected_status: int,
     expected_detail: str,
 ) -> None:
-    _override_theme_service(_FakeThemeService(**service_kwargs))
+    theme_id = uuid4()
+    _override_theme_service(_FakeThemeService(theme_id=theme_id, **service_kwargs))
 
-    res = await client.put("/themes/Hobby", json={"color": "#FFFFFF"})
+    res = await client.put(f"/themes/{theme_id}", json={"color": "#FFFFFF"})
 
     assert_json_detail(res, status_code=expected_status, detail=expected_detail)
 
@@ -224,7 +243,7 @@ async def test_create_theme_accepts_valid_csrf_token(client: AsyncClient) -> Non
 async def test_get_theme_page_returns_404_when_missing(client: AsyncClient) -> None:
     _override_theme_service(_FakeThemeService(exists=False))
 
-    res = await client.get("/themes/Missing")
+    res = await client.get(f"/themes/{uuid4()}")
 
     assert_html_response(res, status_code=404)
 
@@ -232,7 +251,10 @@ async def test_get_theme_page_returns_404_when_missing(client: AsyncClient) -> N
 async def test_update_theme_rejects_missing_csrf_token(client: AsyncClient) -> None:
     app.dependency_overrides.pop(require_csrf, None)
 
-    res = await client.put("/themes/Hobby", json={"color": "#FFFFFF"})
+    theme_id = uuid4()
+    _override_theme_service(_FakeThemeService(theme_id=theme_id))
+
+    res = await client.put(f"/themes/{theme_id}", json={"color": "#FFFFFF"})
 
     assert_json_detail(res, status_code=403, detail=PUBLIC_ERRORS[403])
 

--- a/tests/integration/test_themes.py
+++ b/tests/integration/test_themes.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -37,6 +39,26 @@ async def delete_theme(client, id):
         f"/themes/{id}",
         headers=await with_csrf_headers(client),
     )
+
+
+async def get_theme_id_by_name(client, name: str) -> str:
+    response = await client.get("/themes/")
+    assert response.status_code == 200
+
+    # theme-card содержит атрибуты data-theme-id и data-theme-name
+    pattern = (
+        r'data-theme-id="(?P<id>[^"]+)"[^>]*data-theme-name="'
+        + re.escape(name)
+        + r'"'
+    )
+    match = re.search(pattern, response.text)
+    assert match, f"Theme id not found for name={name!r}"
+    theme_id = match.group("id").strip()
+    # Важно: роуты ожидают валидный UUID, иначе будет 422
+    import uuid
+
+    uuid.UUID(theme_id)
+    return theme_id
 
 
 @pytest.mark.asyncio
@@ -104,8 +126,9 @@ async def test_create_theme_without_name_error(client):
 @pytest.mark.asyncio
 async def test_update_theme(client):
     await create_theme(client=client, name=NAME)
+    theme_id = await get_theme_id_by_name(client, NAME)
     response = await update_theme(
-        client=client, id=NAME, name="Новое название", color="#FFFFFF"
+        client=client, id=theme_id, name="Новое название", color="#FFFFFF"
     )
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
@@ -131,7 +154,8 @@ async def test_get_themes_list_page(client):
 @pytest.mark.asyncio
 async def test_delete_theme(client):
     await create_theme(client=client, name=NAME)
-    response = await delete_theme(client=client, id=NAME)
+    theme_id = await get_theme_id_by_name(client, NAME)
+    response = await delete_theme(client=client, id=theme_id)
     assert response.status_code == 204
 
     response = await client.get("/themes/")
@@ -142,7 +166,8 @@ async def test_delete_theme(client):
 @pytest.mark.asyncio
 async def test_get_update_theme_page(client):
     await create_theme(client=client, name=NAME)
-    response = await client.get(f"/themes/{NAME}")
+    theme_id = await get_theme_id_by_name(client, NAME)
+    response = await client.get(f"/themes/{theme_id}")
     assert response.status_code == 200
     assert NAME in response.text
 
@@ -173,26 +198,27 @@ async def test_theme_owner_scope_hides_foreign_theme_and_blocks_mutations(
 
     create_response = await create_theme(client=secondary_client, name=foreign_theme_name)
     assert create_response.status_code == 303
+    foreign_theme_id = await get_theme_id_by_name(secondary_client, foreign_theme_name)
 
     list_response = await client.get("/themes/")
     assert list_response.status_code == 200
     assert foreign_theme_name not in list_response.text
 
-    detail_response = await client.get(f"/themes/{foreign_theme_name}")
+    detail_response = await client.get(f"/themes/{foreign_theme_id}")
     assert detail_response.status_code == 404
     assert "Тема не найдена" in detail_response.text
 
     update_response = await update_theme(
         client=client,
-        id=foreign_theme_name,
-        name="Попытка чужого обновления",
+        id=foreign_theme_id,
+        name="Чужое обновление",
     )
     assert update_response.status_code == 404
 
-    delete_response = await delete_theme(client=client, id=foreign_theme_name)
+    delete_response = await delete_theme(client=client, id=foreign_theme_id)
     assert delete_response.status_code == 404
 
-    owner_detail_response = await secondary_client.get(f"/themes/{foreign_theme_name}")
+    owner_detail_response = await secondary_client.get(f"/themes/{foreign_theme_id}")
     assert owner_detail_response.status_code == 200
     assert foreign_theme_name in owner_detail_response.text
 

--- a/tests/unit/test_theme_service.py
+++ b/tests/unit/test_theme_service.py
@@ -305,7 +305,7 @@ async def test_delete_theme_deletes_when_theme_exists():
     repo.get_by_name_result = old
     service = ThemeService(theme_repo=repo)
 
-    await service.delete_theme("Hobby")
+    await service.delete_theme(old.id)
     assert repo.delete_called_with == old.id
 
 


### PR DESCRIPTION
Fixes #1

## Summary
- use UUID for theme edit/delete routes instead of theme name
- avoid route issues caused by spaces or special characters in theme names
- keep theme name only for display purposes

## Why
Using the theme name as a route parameter is unstable because it is user-controlled and may contain characters that break routing.